### PR TITLE
Add support for hfl deployments on Azure

### DIFF
--- a/cczoo/horizontal_fl/build_docker_image.sh
+++ b/cczoo/horizontal_fl/build_docker_image.sh
@@ -22,6 +22,13 @@ else
     tag=$1
 fi
 
+if  [ -z "$AZURE" ] ; then
+    azure=
+else
+    azure=1
+fi
+
+
 # You can remove build-arg http_proxy and https_proxy if your network doesn't need it
 # no_proxy="localhost,127.0.0.0/1"
 # proxy_server="" # your http proxy server
@@ -33,4 +40,5 @@ DOCKER_BUILDKIT=0 docker build \
     --network=host \
     --build-arg http_proxy=${proxy_server} \
     --build-arg https_proxy=${proxy_server} \
-    --build-arg no_proxy=${no_proxy}
+    --build-arg no_proxy=${no_proxy} \
+    --build-arg AZURE=${azure}

--- a/cczoo/horizontal_fl/hfl-tensorflow/test-sgx.sh
+++ b/cczoo/horizontal_fl/hfl-tensorflow/test-sgx.sh
@@ -34,7 +34,7 @@ function make_custom_env() {
     export TF_GRPC_SGX_RA_TLS_ENABLE=on
     export TF_DISABLE_MKL=0
     export TF_ENABLE_MKL_NATIVE_FORMAT=1
-    export parallel_num_threads=4
+    export parallel_num_threads=2
     export INTRA_OP_PARALLELISM_THREADS=$parallel_num_threads
     export INTER_OP_PARALLELISM_THREADS=$parallel_num_threads
     export KMP_SETTINGS=1
@@ -61,13 +61,13 @@ elif [ "$ROLE" == "ps0" ]; then
     fi
 elif [ "$ROLE" == "worker0" ]; then
     make_custom_env
-    taskset -c 8-11 stdbuf -o0 gramine-sgx python -u train.py --task_index=0 --job_name=worker $PS_HOSTS $WORKER_HOSTS 2>&1 | runtime_logfilter | tee -a worker0-gramine-python.log &
+    taskset -c 8-9 stdbuf -o0 gramine-sgx python -u train.py --task_index=0 --job_name=worker $PS_HOSTS $WORKER_HOSTS 2>&1 | runtime_logfilter | tee -a worker0-gramine-python.log &
     if [ "$DEBUG" != "0" ]; then
         wait && kill -9 `pgrep -f gramine`
     fi
 elif [ "$ROLE" == "worker1" ]; then
     make_custom_env
-    taskset -c 11-15 stdbuf -o0 gramine-sgx python -u train.py --task_index=1 --job_name=worker $PS_HOSTS $WORKER_HOSTS 2>&1 | runtime_logfilter | tee -a worker1-gramine-python.log &
+    taskset -c 12-13 stdbuf -o0 gramine-sgx python -u train.py --task_index=1 --job_name=worker $PS_HOSTS $WORKER_HOSTS 2>&1 | runtime_logfilter | tee -a worker1-gramine-python.log &
     if [ "$DEBUG" != "0" ]; then
         wait && kill -9 `pgrep -f gramine`
     fi

--- a/cczoo/horizontal_fl/horizontal_fl.dockerfile
+++ b/cczoo/horizontal_fl/horizontal_fl.dockerfile
@@ -59,20 +59,20 @@ RUN if [ -z "$AZURE" ]; then \
         apt-get install -y libsgx-dcap-default-qpl libsgx-dcap-default-qpl-dev; \
     else \
         # Build for Azure, so install the Azure DCAP Client (Release 1.10.0) \
-        AZUREDIR=/azure; \
-        apt-get install -y libssl-dev libcurl4-openssl-dev pkg-config software-properties-common; \
-        add-apt-repository ppa:team-xbmc/ppa -y; \
-        apt-get update; \
-        apt-get install -y nlohmann-json3-dev; \
-        git clone https://github.com/microsoft/Azure-DCAP-Client ${AZUREDIR}; \
-        cd ${AZUREDIR}; \
-        git checkout 1.10.0; \
-        git submodule update --recursive --init; \
-        cd src/Linux; \
-        ./configure; \
-        make DEBUG=1; \
-        make install; \
-        cp libdcap_quoteprov.so /usr/lib/x86_64-linux-gnu/; \
+        AZUREDIR=/azure \
+        && apt-get install -y libssl-dev libcurl4-openssl-dev pkg-config software-properties-common \
+        && add-apt-repository ppa:team-xbmc/ppa -y \
+        && apt-get update \
+        && apt-get install -y nlohmann-json3-dev \
+        && git clone https://github.com/microsoft/Azure-DCAP-Client ${AZUREDIR} \
+        && cd ${AZUREDIR} \
+        && git checkout 1.10.0 \
+        && git submodule update --recursive --init \
+        && cd src/Linux \
+        && ./configure \
+        && make DEBUG=1 \
+        && make install \
+        && cp libdcap_quoteprov.so /usr/lib/x86_64-linux-gnu/; \
     fi
 
 # Gramine

--- a/cczoo/horizontal_fl/horizontal_fl.dockerfile
+++ b/cczoo/horizontal_fl/horizontal_fl.dockerfile
@@ -17,6 +17,9 @@
 
 FROM ubuntu:18.04
 
+# Optional build argument to select a build for Azure
+ARG AZURE
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV INSTALL_PREFIX=/usr/local
 ENV LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:${INSTALL_PREFIX}/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}
@@ -48,7 +51,29 @@ RUN echo "deb [trusted=yes arch=amd64] https://download.01.org/intel-sgx/sgx_rep
 RUN apt-get install -y libsgx-pce-logic libsgx-ae-qve libsgx-quote-ex libsgx-quote-ex-dev libsgx-qe3-logic sgx-aesm-service
 
 # Install SGX-DCAP
-RUN apt-get install -y libsgx-dcap-ql-dev libsgx-dcap-default-qpl libsgx-dcap-quote-verify-dev libsgx-dcap-default-qpl-dev
+RUN apt-get install -y libsgx-dcap-ql-dev libsgx-dcap-quote-verify-dev
+
+# Install SGX-DCAP quote provider library
+RUN if [ -z "$AZURE" ]; then \
+        # Not a build for Azure, so install the default quote provider library \
+        apt-get install -y libsgx-dcap-default-qpl libsgx-dcap-default-qpl-dev; \
+    else \
+        # Build for Azure, so install the Azure DCAP Client (Release 1.10.0) \
+        AZUREDIR=/azure; \
+        apt-get install -y libssl-dev libcurl4-openssl-dev pkg-config software-properties-common; \
+        add-apt-repository ppa:team-xbmc/ppa -y; \
+        apt-get update; \
+        apt-get install -y nlohmann-json3-dev; \
+        git clone https://github.com/microsoft/Azure-DCAP-Client ${AZUREDIR}; \
+        cd ${AZUREDIR}; \
+        git checkout 1.10.0; \
+        git submodule update --recursive --init; \
+        cd src/Linux; \
+        ./configure; \
+        make DEBUG=1; \
+        make install; \
+        cp libdcap_quoteprov.so /usr/lib/x86_64-linux-gnu/; \
+    fi
 
 # Gramine
 ENV GRAMINEDIR=/gramine

--- a/cczoo/horizontal_fl/patches/gramine/CI-Examples/ra-tls-mbedtls/build_install.sh
+++ b/cczoo/horizontal_fl/patches/gramine/CI-Examples/ra-tls-mbedtls/build_install.sh
@@ -54,8 +54,6 @@ whereis libsgx_util libsgx_dcap_quoteverify libdcap_quoteprov.so.*
 whereis libra_tls_attest libra_tls_verify_dcap libra_tls_verify_epid libra_tls_verify_dcap_graphene
 
 ls -l /usr/lib/x86_64-linux-gnu/libsgx_dcap_quoteverify.so*
-ls -l /usr/lib/x86_64-linux-gnu/libdcap_quoteprov.so*
-ls -l /usr/lib/x86_64-linux-gnu/libsgx_default_qcnl_wrapper.so*
 
 env
 

--- a/cczoo/horizontal_fl/patches/gramine/patches/ra_tls_verify_dcap.diff
+++ b/cczoo/horizontal_fl/patches/gramine/patches/ra_tls_verify_dcap.diff
@@ -70,7 +70,7 @@ index 8ce518da..4c854410 100644
                                /*p_qve_report_info=*/NULL, supplemental_data_size,
                                supplemental_data);
      if (ret) {
-+        printf("sgx_qv_verify_quote failed");
++        printf("sgx_qv_verify_quote failed: 0x%04x ", ret);
          ret = MBEDTLS_ERR_X509_CERT_VERIFY_FAILED;
          goto out;
      }

--- a/documents/readthedoc/docs/source/Cloud/cloudDeployment.md
+++ b/documents/readthedoc/docs/source/Cloud/cloudDeployment.md
@@ -277,3 +277,91 @@ Validated Solution&nbsp; </span>
 		</tr>
 	</tbody>
 </table>
+
+
+---
+
+## Microsoft Azure
+
+Microsoft Azure [DCsv3-series](https://docs.microsoft.com/en-us/azure/virtual-machines/dcv3-series) instances support Intel® SGX encrypted computing technology.
+
+The following is the configuration of the DCsv3-series instance used:
+
+<table border="1" cellpadding="1" cellspacing="1" style="width:500px;">
+	<tbody>
+		<tr>
+			<td colspan="2">
+				<span>&nbsp; &nbsp; Public Cloud </span>
+			</td>
+			<td>
+				<span>Microsoft Azure </span>
+			</td>
+		</tr>
+		<tr>
+			<td rowspan="6" style="text-align:left;">
+				<p>
+					<span>&nbsp;</span>
+				</p>
+				<p>
+					<span>Instance&nbsp; </span>
+				</p>
+			</td>
+			<td style="text-align:left;">
+				<span>Type</span>
+			</td>
+			<td>
+				<div>
+					<span>Standard_DC16s_v3</span>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td style="text-align:left;">
+				<span>Kernel</span>
+			</td>
+			<td>
+				<div>
+					<span>5.13.0-1031-azure</span>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td style="text-align:left;">
+				<span>OS</span>
+			</td>
+			<td>
+				<span>Ubuntu Server 20.04 LTS - Gen2</span>
+			</td>
+		</tr>
+		<tr>
+			<td style="text-align:left;">
+				<span>Memory</span>
+			</td>
+			<td>
+				<span>128G (64G EPC Memory)</span>
+			</td>
+		</tr>
+		<tr>
+			<td style="text-align:left;">
+				<span>vCPU</span>
+			</td>
+			<td>
+				<span>16</span>
+			</td>
+		</tr>
+			<td colspan="2">
+				<span><br />
+<br />
+<br />
+Validated Solution&nbsp; </span>
+			</td>
+			<td>
+				<ul>
+					<li>
+						<a href="https://cczoo.readthedocs.io/en/latest/Solutions/horizontal-federated-learning/hfl.html"><span>Horizontal Federated Learning&nbsp;</span></a>
+					</li>
+				</ul>
+			</td>
+		</tr>
+	</tbody>
+</table>

--- a/documents/readthedoc/docs/source/Cloud/cloudDeployment.md
+++ b/documents/readthedoc/docs/source/Cloud/cloudDeployment.md
@@ -185,19 +185,16 @@ The configuration of the M6ce instance as blow:
 	<tbody>
 		<tr>
 			<td colspan="2">
-				<span>&nbsp; &nbsp; Public Cloud </span> 
+				<strong>&nbsp; &nbsp; Public Cloud</strong> 
 			</td>
-			<td>
-				<span>ByteDance Cloud </span> 
+			<td><strong>ByteDance Cloud</strong>
 			</td>
 		</tr>
 		<tr>
-			<td rowspan="6" style="text-align:left;">
-				<p>
-					<span>&nbsp;</span> 
+			<td rowspan="6" style="text-align: left;">
+				<p>&nbsp;
 				</p>
-				<p>
-					<span>Instance&nbsp; </span> 
+				<p><strong>Instance&nbsp;</strong>
 				</p>
 			</td>
 			<td style="text-align:left;">
@@ -252,12 +249,12 @@ The configuration of the M6ce instance as blow:
 			</td>
 		</tr>
 		<tr>
-			<td colspan="2">
-				<span><br />
-<br />
-<br />
-Validated Solution&nbsp; </span> 
-			</td>
+		<td colspan="2">
+			<br />
+			<br />
+			<br />
+			<strong>Validated Solution&nbsp;</strong>
+		</td>
 			<td>
 				<ul>
 					<li>
@@ -291,19 +288,16 @@ The following is the configuration of the DCsv3-series instance used:
 	<tbody>
 		<tr>
 			<td colspan="2">
-				<span>&nbsp; &nbsp; Public Cloud </span>
+				<strong>&nbsp; &nbsp; Public Cloud</strong>
 			</td>
-			<td>
-				<span>Microsoft Azure </span>
+			<td><strong>Microsoft Azure</strong>
 			</td>
 		</tr>
 		<tr>
-			<td rowspan="6" style="text-align:left;">
-				<p>
-					<span>&nbsp;</span>
+			<td rowspan="5" style="text-align: left;">
+				<p>&nbsp;
 				</p>
-				<p>
-					<span>Instance&nbsp; </span>
+				<p><strong>Instance&nbsp;</strong>
 				</p>
 			</td>
 			<td style="text-align:left;">
@@ -349,12 +343,12 @@ The following is the configuration of the DCsv3-series instance used:
 				<span>16</span>
 			</td>
 		</tr>
-			<td colspan="2">
-				<span><br />
-<br />
-<br />
-Validated Solution&nbsp; </span>
-			</td>
+		<td colspan="2">
+			<br />
+			<br />
+			<br />
+			<strong>Validated Solution&nbsp;</strong>
+		</td>
 			<td>
 				<ul>
 					<li>

--- a/documents/readthedoc/docs/source/Cloud/cloudDeployment.md
+++ b/documents/readthedoc/docs/source/Cloud/cloudDeployment.md
@@ -19,7 +19,7 @@ by Alibaba Cloud. It builds security-enhanced instance families [g7t, c7t, r7t](
 based on Intel® SGX technology to provide a trusted and confidential environment
 with a higher security level.
 
-The configuration of the ECS instance as blow:
+The configuration of the ECS instance as below:
 
 <table border="1" cellpadding="1" cellspacing="1" style="width:500px">
   <tbody>
@@ -99,7 +99,7 @@ The configuration of the ECS instance as blow:
 Tencent Cloud Virtual Machine (CVM) provide one instance named [M6ce](https://cloud.tencent.com/document/product/213/11518#M6ce),
 which supports Intel® SGX encrypted computing technology.
 
-The configuration of the M6ce instance as blow:
+The configuration of the M6ce instance as below:
 
 <table border="1" cellpadding="1" cellspacing="1" style="width:500px">
   <tbody>
@@ -179,7 +179,7 @@ ByteDance Cloud (Volcengine SGX Instances) provides the instance named `ebmg2t`,
 which supports Intel® SGX encrypted computing technology. Now ByteDance Cloud only
 provides SGX instance based on bare metal for customers in whitelist.
 
-The configuration of the M6ce instance as blow:
+The configuration of the M6ce instance as below:
 
 <table border="1" cellpadding="1" cellspacing="1" style="width:500px;">
 	<tbody>

--- a/documents/readthedoc/docs/source/Solutions/horizontal-federated-learning/hfl.md
+++ b/documents/readthedoc/docs/source/Solutions/horizontal-federated-learning/hfl.md
@@ -69,6 +69,11 @@ Steps **②**-**⑥** will be repeated continuously during the training process.
 - container num: 3
 
 ### Build Docker image
+For deployments on Microsoft Azure:
+```shell
+AZURE=1 ./build_docker_image.sh
+```
+For other cloud deployments:
 ```shell
 ./build_docker_image.sh
 ```
@@ -89,7 +94,7 @@ If running locally, please fill in the local PCCS server address in `<PCCS ip ad
 ./start_aesm_service.sh
 ```
 
-If running in the cloud, please modify the `PCCS server address` in the `sgx_default_qcnl.conf` file and fill in the PCCS address of the cloud and ignore the `<PCCS ip addr>` parameter.
+If running in the cloud (except for Microsoft Azure), please modify the `PCCS server address` in the `sgx_default_qcnl.conf` file and fill in the PCCS address of the cloud and ignore the `<PCCS ip addr>` parameter.
 
 ### Run the training scripts
 Run the script for the corresponding job in each container.
@@ -119,7 +124,7 @@ Cloud. It builds security-enhanced instance families [g7t, c7t, r7t](https://hel
 based on Intel® SGX technology to provide a trusted and confidential environment
 with a higher security level.
 
-The configuration of the ECS instance as blow:
+The configuration of the ECS instance as below:
 
 - Instance Type  : [g7t](https://help.aliyun.com/document_detail/108490.htm#section-bew-6jv-c0k).
 - Instance Kernel: 4.19.91-24
@@ -135,7 +140,7 @@ The configuration of the ECS instance as blow:
 Tencent Cloud Virtual Machine (CVM) provide one instance named [M6ce](https://cloud.tencent.com/document/product/213/11518#M6ce),
 which supports Intel® SGX encrypted computing technology.
 
-The configuration of the M6ce instance as blow:
+The configuration of the M6ce instance as below:
 
 - Instance Type  : [M6ce.4XLARGE128](https://cloud.tencent.com/document/product/213/11518#M6ce)
 - Instance Kernel: 5.4.119-19-0009.1
@@ -146,17 +151,13 @@ The configuration of the M6ce instance as blow:
 
 ***Notice***: Please replace server link in `sgx_default_qcnl.conf` included in the dockerfile with Tencent PCCS server address.
 
-<div id="refer-anchor-1"></div>
-
-- [1] [Knauth, Thomas, et al. "Integrating remote attestation with transport layer security." arXiv preprint arXiv:1801.05863 (2018).](https://arxiv.org/pdf/1801.05863)
-
 
 ### 3. ByteDance Cloud
 
 ByteDance Cloud (Volcengine SGX Instances) provides the instance named `ebmg2t`,
 which supports Intel® SGX encrypted computing technology.
 
-The configuration of the ebmg2t instance as blow:
+The configuration of the ebmg2t instance as below:
 
 - Instance Type  : `ecs.ebmg2t.32xlarge`.
 - Instance Kernel: kernel-5.15
@@ -164,3 +165,21 @@ The configuration of the ebmg2t instance as blow:
 - Instance Encrypted Memory: 256G
 - Instance vCPU  : 16
 - Instance SGX PCCS Server: `sgx-dcap-server.bytedance.com`.
+
+### 4. Microsoft Azure
+
+Microsoft Azure [DCsv3-series](https://docs.microsoft.com/en-us/azure/virtual-machines/dcv3-series) instances support Intel® SGX encrypted computing technology.
+
+The following is the configuration of the DCsv3-series instance used:
+
+- Instance Type  : Standard_DC16s_v3
+- Instance Kernel: 5.13.0-1031-azure
+- Instance OS    : Ubuntu Server 20.04 LTS - Gen2
+- Instance Encrypted Memory: 64G
+- Instance vCPU  : 16
+
+***Notice***: Microsoft Azure uses the Azure DCAP Client instead of the default SGX quote provider library, so `sgx_default_qcnl.conf` is not used.
+
+<div id="refer-anchor-1"></div>
+
+- [1] [Knauth, Thomas, et al. "Integrating remote attestation with transport layer security." arXiv preprint arXiv:1801.05863 (2018).](https://arxiv.org/pdf/1801.05863)


### PR DESCRIPTION
## Description of the PR
- Add support for Horizontal Federated Learning deployments on Azure
- Bind two cores (instead of four) to hfl workers to improve training stability
- Update hfl documentation

## How to test this PR?
- Test hfl deployment on Azure
- Regression test non-Azure hfl deployment
- Review documentation changes


