### PR TITLE
Branch0.1/tf serving cluster

### DIFF
--- a/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/secret_prov/build_secret_prov_image.sh
+++ b/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/secret_prov/build_secret_prov_image.sh
@@ -23,9 +23,13 @@ else
     tag=$1
 fi
 
+if  [ -z "$AZURE" ] ; then
+    azure=
+else
+    azure=1
+fi
 
 DOCKER_BUILDKIT=0 docker build \
     -f secret_prov.dockerfile . \
-    -t secret_prov_server:${tag}
-
-
+    -t secret_prov_server:${tag} \
+    --build-arg AZURE=${azure}

--- a/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/secret_prov/secret_prov.dockerfile
+++ b/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/secret_prov/secret_prov.dockerfile
@@ -16,6 +16,9 @@
 
 FROM ubuntu:18.04
 
+# Optional build argument to select a build for Azure
+ARG AZURE
+
 ENV GRAMINEDIR=/gramine
 ENV ISGX_DRIVER_PATH=${GRAMINEDIR}/driver
 ENV WORK_BASE_PATH=${GRAMINEDIR}/CI-Examples/ra-tls-secret-prov
@@ -61,8 +64,30 @@ RUN apt-get update
 # Install SGX PSW
 RUN apt-get install -y libsgx-pce-logic libsgx-ae-qve libsgx-quote-ex libsgx-qe3-logic sgx-aesm-service
 
-# Install DCAP
-RUN apt-get install -y libsgx-dcap-ql-dev libsgx-dcap-default-qpl libsgx-dcap-quote-verify-dev
+# Install SGX DCAP
+RUN apt-get install -y libsgx-dcap-ql-dev libsgx-dcap-quote-verify-dev
+
+# Install SGX-DCAP quote provider library
+RUN if [ -z "$AZURE" ]; then \
+        # Not a build for Azure, so install the default quote provider library \
+        apt-get install -y libsgx-dcap-default-qpl; \
+    else \
+        # Build for Azure, so install the Azure DCAP Client (Release 1.10.0) \
+        AZUREDIR=/azure; \
+        apt-get install -y libssl-dev libcurl4-openssl-dev pkg-config software-properties-common; \
+        add-apt-repository ppa:team-xbmc/ppa -y; \
+        apt-get update; \
+        apt-get install -y nlohmann-json3-dev; \
+        git clone https://github.com/microsoft/Azure-DCAP-Client ${AZUREDIR}; \
+        cd ${AZUREDIR}; \
+        git checkout 1.10.0; \
+        git submodule update --recursive --init; \
+        cd src/Linux; \
+        ./configure; \
+        make DEBUG=1; \
+        make install; \
+        cp libdcap_quoteprov.so /usr/lib/x86_64-linux-gnu/; \
+    fi
 
 # Clone Gramine and Init submodules
 RUN git clone https://github.com/gramineproject/gramine.git ${GRAMINEDIR} \

--- a/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/secret_prov/secret_prov.dockerfile
+++ b/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/secret_prov/secret_prov.dockerfile
@@ -73,19 +73,19 @@ RUN if [ -z "$AZURE" ]; then \
         apt-get install -y libsgx-dcap-default-qpl; \
     else \
         # Build for Azure, so install the Azure DCAP Client (Release 1.10.0) \
-        AZUREDIR=/azure; \
-        && apt-get install -y libssl-dev libcurl4-openssl-dev pkg-config software-properties-common; \
-        && add-apt-repository ppa:team-xbmc/ppa -y; \
-        && apt-get update; \
-        && apt-get install -y nlohmann-json3-dev; \
-        && git clone https://github.com/microsoft/Azure-DCAP-Client ${AZUREDIR}; \
-        && cd ${AZUREDIR}; \
-        && git checkout 1.10.0; \
-        && git submodule update --recursive --init; \
-        && cd src/Linux; \
-        && ./configure; \
-        && make DEBUG=1; \
-        && make install; \
+        AZUREDIR=/azure \
+        && apt-get install -y libssl-dev libcurl4-openssl-dev pkg-config software-properties-common \
+        && add-apt-repository ppa:team-xbmc/ppa -y \
+        && apt-get update \
+        && apt-get install -y nlohmann-json3-dev \
+        && git clone https://github.com/microsoft/Azure-DCAP-Client ${AZUREDIR} \
+        && cd ${AZUREDIR} \
+        && git checkout 1.10.0 \
+        && git submodule update --recursive --init \
+        && cd src/Linux \
+        && ./configure \
+        && make DEBUG=1 \
+        && make install \
         && cp libdcap_quoteprov.so /usr/lib/x86_64-linux-gnu/; \
     fi
 

--- a/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/secret_prov/secret_prov.dockerfile
+++ b/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/secret_prov/secret_prov.dockerfile
@@ -74,19 +74,19 @@ RUN if [ -z "$AZURE" ]; then \
     else \
         # Build for Azure, so install the Azure DCAP Client (Release 1.10.0) \
         AZUREDIR=/azure; \
-        apt-get install -y libssl-dev libcurl4-openssl-dev pkg-config software-properties-common; \
-        add-apt-repository ppa:team-xbmc/ppa -y; \
-        apt-get update; \
-        apt-get install -y nlohmann-json3-dev; \
-        git clone https://github.com/microsoft/Azure-DCAP-Client ${AZUREDIR}; \
-        cd ${AZUREDIR}; \
-        git checkout 1.10.0; \
-        git submodule update --recursive --init; \
-        cd src/Linux; \
-        ./configure; \
-        make DEBUG=1; \
-        make install; \
-        cp libdcap_quoteprov.so /usr/lib/x86_64-linux-gnu/; \
+        && apt-get install -y libssl-dev libcurl4-openssl-dev pkg-config software-properties-common; \
+        && add-apt-repository ppa:team-xbmc/ppa -y; \
+        && apt-get update; \
+        && apt-get install -y nlohmann-json3-dev; \
+        && git clone https://github.com/microsoft/Azure-DCAP-Client ${AZUREDIR}; \
+        && cd ${AZUREDIR}; \
+        && git checkout 1.10.0; \
+        && git submodule update --recursive --init; \
+        && cd src/Linux; \
+        && ./configure; \
+        && make DEBUG=1; \
+        && make install; \
+        && cp libdcap_quoteprov.so /usr/lib/x86_64-linux-gnu/; \
     fi
 
 # Clone Gramine and Init submodules

--- a/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/tf_serving/build_gramine_tf_serving_image.sh
+++ b/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/tf_serving/build_gramine_tf_serving_image.sh
@@ -23,10 +23,18 @@ else
     tag=$1
 fi
 
+if  [ -z "$AZURE" ] ; then
+    azure=
+else
+    azure=1
+fi
+
 # You can remove build-arg http_proxy and https_proxy if your network doesn't need it
-proxy_server="http://test-proxy:port"
+proxy_server=""
+
 DOCKER_BUILDKIT=0 docker build \
     -f gramine_tf_serving.dockerfile . \
     -t gramine_tf_serving:${tag} \
     --build-arg http_proxy=${proxy_server} \
-    --build-arg https_proxy=${proxy_server} 
+    --build-arg https_proxy=${proxy_server} \
+    --build-arg AZURE=${azure}

--- a/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/tf_serving/run_gramine_tf_serving.sh
+++ b/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/tf_serving/run_gramine_tf_serving.sh
@@ -92,7 +92,7 @@ while getopts "h?r:i:p:m:s:a:e:" OPT; do
 done
 
 docker run \
-    -it \
+    -itd \
     --device /dev/sgx_enclave:/dev/sgx/enclave \
     --device /dev/sgx_provision:/dev/sgx/provision \
     --add-host=${attestation_hosts} \

--- a/cczoo/tensorflow-serving-cluster/tensorflow-serving/kubernetes/deploy.yaml
+++ b/cczoo/tensorflow-serving-cluster/tensorflow-serving/kubernetes/deploy.yaml
@@ -57,8 +57,8 @@ spec:
     spec:
       containers:
       - name: gramine-tf-serving-container
-        image: gramine_tf_serving:{YOUR TAG}
-        imagePullPolicy: Never
+        image: localhost:5000/gramine_tf_serving
+        imagePullPolicy: IfNotPresent
         env:
         - name: model_name
           value: "resnet50-v15-fp32"
@@ -71,13 +71,13 @@ spec:
         - name: session_parallelism
           value: "0"
         - name: intra_op_parallelism
-          value: "32"
+          value: "2"
         - name: inter_op_parallelism
-          value: "32"
+          value: "2"
         - name: OMP_NUM_THREADS
-          value: "32"
+          value: "2"
         - name: MKL_NUM_THREADS
-          value: "32"
+          value: "2"
         - name: KMP_BLOCKTIME
           value: "0"
         - name: ssl_config_file
@@ -85,7 +85,7 @@ spec:
         - name: SGX
           value: "1"
         - name: ISGX_DRIVER_PATH
-          value: "/gramine/driver/driver/linux/include"
+          value: "/gramine/driver"
         - name: WORK_BASE_PATH
           value: "/gramine/CI-Examples/tensorflow-serving-cluster/tensorflow-serving"
         - name: http_proxy
@@ -101,28 +101,28 @@ spec:
         - name: sgx-path
           mountPath: /dev/sgx
         - name: model-path
-          mountPath: /gramine/CI-Examples/tensorflow-serving-cluster/tensorflow-serving/models/resnet50-v15-fp32
+          mountPath: /gramine/CI-Examples/tensorflow-serving-cluster/tensorflow-serving/models
         - name: ssl-path
           mountPath: /gramine/CI-Examples/tensorflow-serving-cluster/tensorflow-serving/ssl.cfg
-        - name: asem-pgramine
-          mountPath: /var/run/aesmd/aesm
+        - name: aesm-path
+          mountPath: /var/run/aesmd/aesm.socket
         securityContext:
           privileged: true
         resources:
           limits:
-            cpu: "32"
+            cpu: "2"
           requests:
-            cpu: "32"
+            cpu: "2"
       volumes:
       - name: sgx-path
         hostPath:
           path: /dev/sgx
       - name: model-path
         hostPath:
-          path: <Your gramine repository>/CI-Examples/tensorflow-serving-cluster/tensorflow_serving/models/resnet50-v15-fp32
+          path: <Your confidential-computing-zoo path>/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/tf_serving/models
       - name: ssl-path
         hostPath:
-          path: <Your gramine repository>/CI-Examples/tensorflow-serving-cluster/tensorflow_serving/ssl_configure/ssl.cfg
-      - name: asem-path
+          path: <Your confidential-computing-zoo path>/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/tf_serving/ssl_configure/ssl.cfg
+      - name: aesm-path
         hostPath:
-          path: /var/run/aesmd/aesm
+          path: /var/run/aesmd/aesm.socket

--- a/cczoo/tensorflow-serving-cluster/tensorflow-serving/setup_azure_vm.sh
+++ b/cczoo/tensorflow-serving-cluster/tensorflow-serving/setup_azure_vm.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/bash
+
+# exit when any command fails
+set -e
+
+# Install general dependencies
+sudo apt-get install -y python3-pip libcurl4-openssl-dev libssl-dev pkg-config
+sudo add-apt-repository ppa:team-xbmc/ppa -y
+sudo apt-get update
+sudo apt-get install nlohmann-json3-dev
+pip3 install tensorflow==2.4.0
+pip3 install protobuf==3.20
+
+# Install Intel SGX DCAP dependencies
+echo "deb [trusted=yes arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
+sudo apt-get update
+sudo apt-get install -y sgx-aesm-service libsgx-dcap-ql-dev libsgx-dcap-quote-verify-dev
+
+# Build and install Azure DCAP Client 1.10.0 release
+cd ~
+git clone https://github.com/microsoft/Azure-DCAP-Client; cd Azure-DCAP-Client/
+git checkout 1.10.0; git submodule update --recursive --init
+cd src/Linux/; ./configure; make DEBUG=1
+sudo make install
+sudo cp libdcap_quoteprov.so /usr/lib/x86_64-linux-gnu/

--- a/documents/readthedoc/docs/source/Cloud/cloudDeployment.md
+++ b/documents/readthedoc/docs/source/Cloud/cloudDeployment.md
@@ -2,10 +2,10 @@
 
 Solutions and incubating component projects in CCZoo are constantly extended to
 be validated in public clouds to verify the versatility, stability, robustness.
-We will provide detailed configurations of each public clouds for reference, and
+We will provide detailed configurations of each public cloud for reference, and
 notes of the diversity in each cloud for easy deployment.
 
-We now have validated solutions in Alibaba Cloud, Tencent Cloud.
+We now have validated solutions in Alibaba Cloud, Tencent Cloud, and Microsoft Azure.
 There will be more solutions be validated in more public cloud environments in the
 future.
 
@@ -19,7 +19,7 @@ by Alibaba Cloud. It builds security-enhanced instance families [g7t, c7t, r7t](
 based on Intel® SGX technology to provide a trusted and confidential environment
 with a higher security level.
 
-The configuration of the ECS instance as blow:
+The configuration of the ECS instance as below:
 
 <table border="1" cellpadding="1" cellspacing="1" style="width:500px">
   <tbody>
@@ -77,7 +77,7 @@ The configuration of the ECS instance as blow:
         <br />
         <br />
         <br />
-        Validated Solution</strong>
+        Validated Solutions</strong>
       </td>
       <td>
         <ul>
@@ -99,7 +99,7 @@ The configuration of the ECS instance as blow:
 Tencent Cloud Virtual Machine (CVM) provide one instance named [M6ce](https://cloud.tencent.com/document/product/213/11518#M6ce),
 which supports Intel® SGX encrypted computing technology.
 
-The configuration of the M6ce instance as blow:
+The configuration of the M6ce instance as below:
 
 <table border="1" cellpadding="1" cellspacing="1" style="width:500px">
   <tbody>
@@ -156,7 +156,7 @@ The configuration of the M6ce instance as blow:
         <br />
         <br />
         <br />
-        <strong>Validated Solution&nbsp;</strong>
+        <strong>Validated Solutions&nbsp;</strong>
       </td>
       <td>
         <ul>
@@ -173,3 +173,83 @@ The configuration of the M6ce instance as blow:
 
 ---
 
+## Microsoft Azure
+
+Microsoft Azure [DCsv3-series](https://docs.microsoft.com/en-us/azure/virtual-machines/dcv3-series) instances support Intel® SGX encrypted computing technology.
+
+The following is the configuration of the DCsv3-series instance used:
+
+<table border="1" cellpadding="1" cellspacing="1" style="width:500px;">
+	<tbody>
+		<tr>
+			<td colspan="2">
+				<strong>&nbsp; &nbsp; Public Cloud</strong>
+			</td>
+			<td><strong>Microsoft Azure</strong>
+			</td>
+		</tr>
+		<tr>
+			<td rowspan="5" style="text-align: left;">
+				<p>&nbsp;
+				</p>
+				<p><strong>Instance&nbsp;</strong>
+				</p>
+			</td>
+			<td style="text-align:left;">
+				<span>Type</span>
+			</td>
+			<td>
+				<div>
+					<span>Standard_DC16s_v3</span>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td style="text-align:left;">
+				<span>Kernel</span>
+			</td>
+			<td>
+				<div>
+					<span>5.13.0-1031-azure</span>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td style="text-align:left;">
+				<span>OS</span>
+			</td>
+			<td>
+				<span>Ubuntu Server 20.04 LTS - Gen2</span>
+			</td>
+		</tr>
+		<tr>
+			<td style="text-align:left;">
+				<span>Memory</span>
+			</td>
+			<td>
+				<span>128G (64G EPC Memory)</span>
+			</td>
+		</tr>
+		<tr>
+			<td style="text-align:left;">
+				<span>vCPU</span>
+			</td>
+			<td>
+				<span>16</span>
+			</td>
+		</tr>
+		<td colspan="2">
+			<br />
+			<br />
+			<br />
+			<strong>Validated Solutions&nbsp;</strong>
+		</td>
+			<td>
+				<ul>
+					<li><a href="https://cczoo.readthedocs.io/en/latest/Solutions/tensorflow-serving-cluster/index.html">TensorFlow Serving Cluster PPML&nbsp;</a></li>
+          <li><a href="https://cczoo.readthedocs.io/en/latest/Solutions/horizontal-federated-learning/hfl.html"><span>Horizontal Federated Learning&nbsp;</span></a></li>
+				</ul>
+			</td>
+		</tr>
+	</tbody>
+</table>

--- a/documents/readthedoc/docs/source/Solutions/tensorflow-serving-cluster/index.rst
+++ b/documents/readthedoc/docs/source/Solutions/tensorflow-serving-cluster/index.rst
@@ -368,7 +368,7 @@ For more syntax used in the manifest template, please refer to `Gramine Manifest
 Run the TensorFlow Serving container::
 
     cd <tensorflow_serving dir>/docker/tf_serving
-    cp ssl_configure/ssl.cfg 
+    cp ssl_configure/ssl.cfg .
     ./run_gramine_tf_serving.sh -i gramine_tf_serving:latest -p 8500-8501 -m resnet50-v15-fp32 -s ssl.cfg -a attestation.service.com:<secret_prov_service_container_ip_addr>
    
 *Note*:


### PR DESCRIPTION
## Description of the PR
- Add support for TensorFlow Serving Cluster PPML deployments on Azure
- Start tf-serving container in the background
- Fix tf-serving dockerfile to specify tensorflow-model-server version compatible with Ubuntu 18.04 glibc
- Change tf-serving k8s deployment to only request two cpus, to specify local docker registry, to fix SGX driver path, to fix aesmd socket path, to fix model and ssl config paths
- Update tf-serving documentation

## How to test this PR?
- Test tf-serving deployment on Azure
- Regression test non-Azure tf-serving deployment
- Review documentation changes


