### PR TITLE
Work around python extract tarfile error in encrypted file system

### DIFF
--- a/cczoo/common/docker/gramine/README.md
+++ b/cczoo/common/docker/gramine/README.md
@@ -26,7 +26,8 @@ Execute the following command to build this docker image:
 ```
 base_image=ubuntu:20.04
 image_tag=gramine-sgx-dev:v1.2-ubuntu20.04-latest
-./build_docker_image.sh ${base_image} ${image_tag}
+build_type=release
+./build_docker_image.sh ${base_image} ${image_tag} ${build_type}
 ```
 
 `ubuntu:18.04` and `ubuntu:20.04` could be selected as base_image.

--- a/cczoo/common/docker/gramine/README.md
+++ b/cczoo/common/docker/gramine/README.md
@@ -30,4 +30,4 @@ build_type=release
 ./build_docker_image.sh ${base_image} ${image_tag} ${build_type}
 ```
 
-`ubuntu:18.04` and `ubuntu:20.04` could be selected as base_image.
+`ubuntu:18.04`, `ubuntu:20.04` and `anolisos` could be selected as base_image.

--- a/cczoo/common/docker/gramine/build_docker_image.sh
+++ b/cczoo/common/docker/gramine/build_docker_image.sh
@@ -16,11 +16,23 @@
 #!/bin/bash
 set -e
 
-if  [ "$1" == "anolisos" ] ; then
+function usage_help() {
+    echo -e "usage_help:"
+    echo -e '  ./build_docker_image.sh ${base_image} ${image_tag} ${build_type}'
+    echo -e "  {base_image}"
+    echo -e "       ubuntu:18.04 | ubuntu20.04 | anolisos"
+    echo -e "  {image_tag}"
+    echo -e "       customed image tag"
+    echo -e "  {build_type}"
+    echo -e "       release | debug"
+}
+
+usage_help
+
+if  [ -n "$1" ] ; then
     base_image=$1
 else
     base_image=ubuntu:20.04
-
 fi
 
 if  [ "$2" == "anolisos" ] ; then
@@ -43,7 +55,7 @@ no_proxy="localhost,127.0.0.1"
 
 cd `dirname $0`
 
-if [ ${base_image} == "anolisos" ] ; then
+if [ "${base_image}" == "anolisos" ] ; then
 DOCKER_BUILDKIT=0 docker build \
     --build-arg no_proxy=${no_proxy} \
     --build-arg http_proxy=${proxy_server} \

--- a/cczoo/common/docker/gramine/build_docker_image.sh
+++ b/cczoo/common/docker/gramine/build_docker_image.sh
@@ -23,15 +23,23 @@ else
 
 fi
 
-if  [ -n "$2" ] ; then
+if  [ "$2" == "anolisos" ] ; then
+    image_tag=gramine-sgx-dev:v1.2-anolisos
+elif  [ -n "$2" ] ; then
     image_tag=$2
 else
     image_tag=gramine-sgx-dev:v1.2-ubuntu20.04-latest
 fi
 
+if  [ -n "$3" ] ; then
+    build_type=$3
+else
+    build_type=release
+fi
+
 # You can remove no_proxy and proxy_server if your network doesn't need it
 no_proxy="localhost,127.0.0.1"
-proxy_server="" # your http proxy server
+# proxy_server="" # your http proxy server
 
 cd `dirname $0`
 
@@ -42,8 +50,9 @@ DOCKER_BUILDKIT=0 docker build \
     --build-arg https_proxy=${proxy_server} \
     --build-arg base_image=${base_image} \
     --build-arg BASE_IMAGE=${base_image} \
+    --build-arg BUILD_TYPE=${build_type} \
     -f gramine-sgx-dev:v1.2-anolisos.dockerfile \
-    -t gramine-sgx-dev:v1.2-anolisos \
+    -t ${image_tag} \
     .
 else
 DOCKER_BUILDKIT=0 docker build \
@@ -52,8 +61,9 @@ DOCKER_BUILDKIT=0 docker build \
     --build-arg https_proxy=${proxy_server} \
     --build-arg base_image=${base_image} \
     --build-arg BASE_IMAGE=${base_image} \
+    --build-arg BUILD_TYPE=${build_type} \
     -f gramine-sgx-dev.dockerfile \
-    -t gramine-sgx-dev:v1.2-ubuntu20.04-latest \
+    -t ${image_tag} \
     .
 fi
 cd -

--- a/cczoo/common/docker/gramine/gramine-sgx-dev.dockerfile
+++ b/cczoo/common/docker/gramine/gramine-sgx-dev.dockerfile
@@ -76,7 +76,7 @@ RUN apt-get install -y bison gawk nasm python3-click python3-jinja2 ninja-build 
     libgmp-dev libmpfr-dev libmpc-dev libisl-dev
 
 RUN pip3 install --upgrade pip \
-    && pip3 install toml meson
+    && pip3 install toml meson cryptography
 
 RUN git clone https://github.com/gramineproject/gramine.git ${GRAMINEDIR} \
     && cd ${GRAMINEDIR} \
@@ -89,10 +89,11 @@ RUN git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git ${
 # COPY gramine/patches ${GRAMINEDIR}
 # RUN cd ${GRAMINEDIR} \
 #     && git apply *.diff
-
 # RUN openssl genrsa -3 -out ${SGX_SIGNER_KEY} 3072
+
+ARG BUILD_TYPE=release
 RUN cd ${GRAMINEDIR} \
-    && LD_LIBRARY_PATH="" meson setup build/ --buildtype=debug -Dprefix=${INSTALL_PREFIX} -Ddirect=enabled -Dsgx=enabled -Ddcap=enabled -Dsgx_driver=dcap1.10 -Dsgx_driver_include_path=${ISGX_DRIVER_PATH}/driver/linux/include \
+    && LD_LIBRARY_PATH="" meson setup build/ --buildtype=${BUILD_TYPE} -Dprefix=${INSTALL_PREFIX} -Ddirect=enabled -Dsgx=enabled -Ddcap=enabled -Dsgx_driver=dcap1.10 -Dsgx_driver_include_path=${ISGX_DRIVER_PATH}/driver/linux/include \
     && LD_LIBRARY_PATH="" ninja -C build/ \
     && LD_LIBRARY_PATH="" ninja -C build/ install
 
@@ -117,14 +118,6 @@ RUN apt-get clean all \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf ~/.cache/* \
     && rm -rf /tmp/*
-
-RUN gramine-sgx-gen-private-key
-
-COPY configs /
-
-RUN gramine-sgx-gen-private-key
-
-COPY configs /
 
 RUN gramine-sgx-gen-private-key
 

--- a/cczoo/common/docker/gramine/gramine-sgx-dev:v1.2-anolisos.dockerfile
+++ b/cczoo/common/docker/gramine/gramine-sgx-dev:v1.2-anolisos.dockerfile
@@ -34,7 +34,7 @@ RUN mkdir /opt/intel && cd /opt/intel \
     && sha256sum sgx_rpm_local_repo.tar.gz \
     && tar xvf sgx_rpm_local_repo.tar.gz \
     && yum-config-manager --add-repo file:///opt/intel/sgx_rpm_local_repo \
-    && yum -y --nogpgcheck install libsgx-urts libsgx-launch libsgx-epid libsgx-quote-ex libsgx-dcap-ql libsgx-uae-service libsgx-dcap-quote-verify-devel 
+    && yum -y --nogpgcheck install libsgx-urts libsgx-launch libsgx-epid libsgx-quote-ex libsgx-dcap-ql libsgx-uae-service libsgx-dcap-quote-verify-devel \
     && yum -y groupinstall 'Development Tools'
 
 # COPY patches/libsgx_dcap_quoteverify.so  /usr/lib64/

--- a/cczoo/common/docker/gramine/gramine-sgx-dev:v1.2-anolisos.dockerfile
+++ b/cczoo/common/docker/gramine/gramine-sgx-dev:v1.2-anolisos.dockerfile
@@ -67,9 +67,9 @@ RUN git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git ${
     && cd ${ISGX_DRIVER_PATH} \
     && git checkout ${SGX_DCAP_VERSION}
 
-ENV LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:${INSTALL_PREFIX}/lib64:${LD_LIBRARY_PATH}
+ARG BUILD_TYPE=release
 RUN cd ${GRAMINEDIR} \
-    && LD_LIBRARY_PATH="" meson setup build/ --buildtype=debug -Dprefix=${INSTALL_PREFIX} -Ddirect=enabled -Dsgx=enabled -Ddcap=enabled -Dsgx_driver=dcap1.10 -Dsgx_driver_include_path=${ISGX_DRIVER_PATH}/driver/linux/include \
+    && LD_LIBRARY_PATH="" meson setup build/ --buildtype=${BUILD_TYPE} -Dprefix=${INSTALL_PREFIX} -Ddirect=enabled -Dsgx=enabled -Ddcap=enabled -Dsgx_driver=dcap1.10 -Dsgx_driver_include_path=${ISGX_DRIVER_PATH}/driver/linux/include \
     && LD_LIBRARY_PATH="" ninja -C build/ \
     && LD_LIBRARY_PATH="" ninja -C build/ install
 RUN gramine-sgx-gen-private-key


### PR DESCRIPTION
Fix docker image build error.
Change gramine build type to release to work around python extract tarfile error in encrypted file system.