### PR TITLE
docs: Remove --kubernetes-version in kubeadm init

### DIFF
--- a/documents/readthedoc/docs/source/Solutions/tensorflow-serving-cluster/index.rst
+++ b/documents/readthedoc/docs/source/Solutions/tensorflow-serving-cluster/index.rst
@@ -644,7 +644,7 @@ Create the control plane / master node::
    sudo rm /etc/containerd/config.toml
    containerd config default | sudo tee /etc/containerd/config.toml
    sudo systemctl restart containerd
-   sudo kubeadm init --v=5 --node-name=master-node --pod-network-cidr=10.244.0.0/16 --kubernetes-version=v1.27.1
+   sudo kubeadm init --v=5 --node-name=master-node --pod-network-cidr=10.244.0.0/16
 
    mkdir -p $HOME/.kube
    sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config


### PR DESCRIPTION
## Description of the PR

Removes the `--kubernetes-version` argument in the kubeadm init command during control plane / master node creation in step 3.1 to resolve fatal preflight error caused by kubelet version skew.

Evidently, the use of this argument may have been left over from a time where specifying the version was necessary to correspond to a specific version used in the install_kubernetes.sh script which now installs the latest version.

Updated command has been tested on a new Azure VM.

## How to test this PR?

Follow solution steps listed in [Confidential TF Serving with Kubernetes](https://github.com/intel/confidential-computing-zoo/blob/main/documents/readthedoc/docs/source/Solutions/tensorflow-serving-cluster/index.rst#executing-confidential-tf-serving-with-kubernetes) on a new Azure VM. When completing [steps for section 3.1](https://github.com/intel/confidential-computing-zoo/blob/main/documents/readthedoc/docs/source/Solutions/tensorflow-serving-cluster/index.rst#31-install-kubernetes), use the following, updated command which excludes the `--kubernetes-version` argument.

```sh
sudo kubeadm init --v=5 --node-name=master-node --pod-network-cidr=10.244.0.0/16
```