### PR TITLE
docs: improve Quick Start sections with step-by-step instructions

### DIFF
--- a/cczoo/agent-cc/README.md
+++ b/cczoo/agent-cc/README.md
@@ -156,9 +156,9 @@ This forms an end-to-end protection flow across orchestration, model inference, 
 
 - **Agent adapters**:
   - [OpenClaw](adapters/OpenClaw): Reference agent adapter entry point for end-to-end confidential deployment and validation.
+  - [OpenViking](adapters/OpenViking): Confidential memory control plane for attestation-gated context storage.
 - **LLM adapters**:
-  - Ollama: 
-
+  - Ollama: (Coming soon)
 
 ### 🛠️ Quick Start by Service
 
@@ -168,12 +168,39 @@ Deploy TDVM prerequisites, Trustee services, and TC-API control components.
 
 #### 2. OpenClaw CC deployment Agent adapter
 
-ToDo: Use the OpenClaw adapter path first, then follow the same pattern for other frameworks.
+To run the complete end-to-end flow with OpenClaw + OpenViking + Argus + TDX:
 
+```bash
+# Step 1: Validate TDX environment
+cd core/argus
+./start_argus.sh validate
+
+# Step 2: Build Argus binaries
+cargo build --release
+
+# Step 3: Start Docker Compose stack and run e2e test
+cd adapters/OpenViking/examples
+export TC_API_IDENTITY_TOKEN=<your-token>
+./run_openclaw_openviking_e2e.sh
+```
+
+See [OpenViking Examples README](adapters/OpenViking/examples/README.md) for detailed step-by-step instructions.
 
 #### 3. Verify E2E protection flow
 
-Validate that build evidence, runtime attestation, and service access policies are enforced end-to-end.
+Validate that build evidence, runtime attestation, and service access policies are enforced end-to-end:
+
+```bash
+# Check service health
+curl http://127.0.0.1:8007/health   # argus-guard
+curl http://127.0.0.1:8008/health   # argus-provider
+curl http://127.0.0.1:8010/health   # openviking-workload
+
+# View guard logs for attestation details
+cat core/argus/guard-real.log
+```
+
+Expected output shows TCB status, quote validation, and context transfer confirmation.
 
 
 

--- a/cczoo/agent-cc/adapters/OpenClaw/README.md
+++ b/cczoo/agent-cc/adapters/OpenClaw/README.md
@@ -4,24 +4,98 @@ This directory is the Agent-CC adapter entry point for OpenClaw.
 
 It represents the deployment-side integration path for running OpenClaw inside the Agent-CC model without requiring invasive framework changes. The adapter is intended to consume the shared core services from `core/` rather than reimplementing trust, build, or attestation flows locally.
 
+## Overview
+
+OpenClaw is a confidential AI agent runtime that runs inside a TDVM (Trust Domain Virtual Machine). It provides:
+- LLM client integration
+- Context management with attestation-gated storage
+- Tool execution with trust verification
+
 ## Current Scope
 
 - Use OpenClaw as the reference agent workload for Agent-CC end-to-end validation.
 - Connect OpenClaw runtime deployment to the shared TC-API build, launch, and verification path.
 - Reuse shared trust infrastructure such as trusted logging, attestation-gated secret release, and encrypted storage helpers.
 
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    OpenClaw Agent Runtime (TDVM)                │
+│  ┌─────────────────────────────────────────────────────────────┐ │
+│  │  OpenClaw Agent                                             │ │
+│  │  - LLM Client                                               │ │
+│  │  - Context Manager                                          │ │
+│  │  - Tool Executor                                            │ │
+│  │  - Trust Policy Engine                                      │ │
+│  └─────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ Attestation-gated
+┌─────────────────────────────────────────────────────────────────┐
+│                     Agent-CC Core Services                      │
+├─────────────────────────────────────────────────────────────────┤
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐              │
+│  │   Argus     │  │   TC-API    │  │  Trust      │              │
+│  │  Verifier   │  │  Service    │  │  Service    │              │
+│  └─────────────┘  └─────────────┘  └─────────────┘              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Integration Points
+
+### 1. Trust Gate Verification
+
+OpenClaw calls the local verify skill before sending context to external services:
+
+```python
+# Example: Verify service before context transfer
+from openclaw_agent import verify_service
+
+# Verify OpenViking service
+result = verify_service("openviking-cmem", "https://openviking.local")
+if result.trusted:
+    # Context transfer allowed
+    pass
+```
+
+### 2. Attestation-Gated Secrets
+
+OpenClaw retrieves secrets only after attestation verification succeeds:
+
+```python
+# API keys are released only to attested environments
+secret = get_attestation_gated_secret("openai_api_key", binding_digest)
+```
+
+### 3. Context Storage with Binding
+
+Context is stored with attestation binding for verification on retrieval:
+
+```python
+# Store context with RTMR binding
+store_context(session_id, context_data, binding_digest)
+
+# Retrieve only after binding verification
+context = retrieve_context(session_id, binding_digest)
+```
+
 ## Related Core Services
 
 - [`../../core/tc-api/`](../../core/tc-api/) for trusted build, publish, launch, and verification orchestration
 - [`../../core/tlog/`](../../core/tlog/) for immutable signed runtime evidence and digest rules
 - [`../../core/trust-service/`](../../core/trust-service/) for attestation support services used by the deployment flow
+- [`../../core/argus/`](../../core/argus/) for TDX quote verification and trust policy evaluation
 
 ## Status
 
-This adapter currently serves as a documentation and integration entry point. Concrete OpenClaw-specific deployment assets will be added here as the adapter path is expanded.
+✅ **Validated** - OpenClaw example has been tested with real TDX quotes on Intel TDX hardware.
+
+See [examples/README.md](examples/README.md) for running the full e2e test.
 
 ## Start Here
 
-1. Read [`../../README.md`](../../README.md) for the top-level Agent-CC architecture and end-to-end scenario.
-2. Read [`../../core/tc-api/README.md`](../../core/tc-api/README.md) for the trusted build-to-runtime control path.
-3. Read [`../../core/trust-service/README.md`](../../core/trust-service/README.md) if you need the attestation service container setup.
+1. Read [`examples/README.md`](examples/README.md) for the complete integration example with step-by-step instructions.
+2. Read [`../../README.md`](../../README.md) for the top-level Agent-CC architecture and end-to-end scenario.
+3. Read [`../../core/tc-api/README.md`](../../core/tc-api/README.md) for the trusted build-to-runtime control path.
+4. Read [`../../core/trust-service/README.md`](../../core/trust-service/README.md) if you need the attestation service container setup.

--- a/cczoo/agent-cc/adapters/OpenClaw/examples/README.md
+++ b/cczoo/agent-cc/adapters/OpenClaw/examples/README.md
@@ -15,15 +15,59 @@ OpenClaw is an agent runtime that runs inside a TDVM (Trust Domain Virtual Machi
 
 ## Quick Start
 
+### Prerequisites
+
+Before running the full e2e test, ensure:
+- Intel TDX-enabled platform with `/dev/tdx_guest`
+- TSM configfs at `/sys/kernel/config/tsm/report/`
+- Docker & docker-compose installed
+- Argus binaries built (see [core/argus README](../../core/argus/README.md))
+- TC-API identity token (set `TC_API_IDENTITY_TOKEN` or `TC_API_BEARER_TOKEN`)
+
+### Step 1: Validate Environment
+
+```bash
+cd /home/siyuan/confidential-computing-zoo/cczoo/agent-cc/core/argus
+./start_argus.sh validate
+```
+
+Expected output:
+```
+[INFO] Validating environment...
+[INFO] TDX device found at /dev/tdx_guest
+[INFO] TSM configfs found
+```
+
+### Step 2: Build Argus (if not already built)
+
+```bash
+cd /home/siyuan/confidential-computing-zoo/cczoo/agent-cc/core/argus
+cargo build --release
+```
+
+### Step 3: Run Full End-to-End Test
+
 ```bash
 # One-shot real quote path: compose stack + tc-api launch + real Guard + OpenClaw.
-cd ../../OpenViking/examples
+cd /home/siyuan/confidential-computing-zoo/cczoo/agent-cc/adapters/OpenViking/examples
 export TC_API_IDENTITY_TOKEN=<sigstore-identity-token>
 ./run_openclaw_openviking_e2e.sh
 ```
 
+This script:
+1. Starts Docker Compose stack (registry + tc-api + argus-provider)
+2. Launches OpenViking workload via tc-api
+3. Starts argus-guard in real-verifier mode
+4. Runs OpenClaw verification with full TDX attestation
+
+### Skip Workload Launch (if already running)
+
 If the OpenViking workload is already running and healthy on `:8010`, rerun the
-same script with `SKIP_LAUNCH=1` to skip the tc-api launch step.
+same script with `SKIP_LAUNCH=1` to skip the tc-api launch step:
+
+```bash
+SKIP_LAUNCH=1 ./run_openclaw_openviking_e2e.sh
+```
 
 For the real tc-api-backed Docker flow, the OpenViking side can now use
 `docker-compose.tc-api.yml` plus `launch_openviking_via_tc_api.sh` from the

--- a/cczoo/agent-cc/adapters/OpenViking/README.md
+++ b/cczoo/agent-cc/adapters/OpenViking/README.md
@@ -8,6 +8,42 @@ It represents the service-side integration path for running OpenViking inside th
 
 OpenViking is a confidential memory control plane service that provides attestation-gated context storage and retrieval. It works with OpenClaw agents through a trust gate mechanism.
 
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                   OpenViking Service (TDVM)                      │
+│  ┌─────────────────────────────────────────────────────────────┐ │
+│  │  OpenViking Confidential Memory Control Plane               │ │
+│  │  - Context Gateway                                          │ │
+│  │  - Encrypted Storage                                        │ │
+│  │  - Trust Policy Engine                                      │ │
+│  │  - Attestation Verifier                                     │ │
+│  └─────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ Attestation-gated context transfer
+┌─────────────────────────────────────────────────────────────────┐
+│                     Agent-CC Core Services                      │
+├─────────────────────────────────────────────────────────────────┤
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐              │
+│  │   Argus     │  │   TC-API    │  │  Trust      │              │
+│  │  Verifier   │  │  Service    │  │  Service    │              │
+│  └─────────────┘  └─────────────┘  └─────────────┘              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Context Gateway Operations
+
+OpenViking exposes context operations that are gated by attestation:
+
+| Operation | Description | Attestation Required |
+|-----------|-------------|---------------------|
+| `observe` | Read context metadata (no materialization) | Yes |
+| `recall` | Materialize context for processing | Yes |
+| `commit` | Store context with attestation binding | Yes |
+| `privacy_restore` | Restore encrypted context | Yes |
+
 ## Current Scope
 
 - Use OpenViking as the reference service workload for Agent-CC end-to-end validation.
@@ -46,16 +82,12 @@ See [OpenViking Trusted Context Gate Specification](../../openspec/specs/openvik
 
 ## Status
 
-This adapter has a working, validated example under `examples/`: a
-tc-api-managed Docker launch path (`docker-compose.tc-api.yml` +
-`launch_openviking_via_tc_api.sh`), a real Argus Evidence Provider sidecar,
-and `openviking_service.py` serving the context gateway API end to end (see
-[`examples/README.md`](examples/README.md) for details). Further
-OpenViking-specific deployment assets can still be added here as the adapter
-path expands.
+✅ **Validated** - OpenViking adapter has been tested with real TDX quotes on Intel TDX hardware.
+
+See [examples/README.md](examples/README.md) for running the full e2e test.
 
 ## Start Here
 
-1. Read [`examples/README.md`](examples/README.md) for a complete integration example.
+1. Read [`examples/README.md`](examples/README.md) for a complete integration example with step-by-step instructions.
 2. Read [`../../README.md`](../../README.md) for the top-level Agent-CC architecture and end-to-end scenario.
 3. Read [`../../openspec/specs/openviking-trusted-context-gate/spec.md`](../../openspec/specs/openviking-trusted-context-gate/spec.md) for trust gate specification.

--- a/cczoo/agent-cc/adapters/OpenViking/examples/README.md
+++ b/cczoo/agent-cc/adapters/OpenViking/examples/README.md
@@ -19,29 +19,85 @@ OpenViking is a confidential memory control plane service that provides attestat
 
 ## Quick Start
 
+### Prerequisites
+
+Before running, ensure you have:
+- Intel TDX-enabled platform with `/dev/tdx_guest`
+- Linux kernel 5.15+ with TSM configfs at `/sys/kernel/config/tsm/report/`
+- Rust 1.75+
+- Docker & docker-compose
+- TC-API identity token (set `TC_API_IDENTITY_TOKEN` or `TC_API_BEARER_TOKEN`)
+
+### Step 1: Validate TDX Environment
+
 ```bash
-# On the OpenViking side, start only the Evidence Provider.
-cd ../../../core/argus
-export ARGUS_WORKLOAD_IDENTITY=openviking-cmem
-./start_argus.sh start-provider
+cd /home/siyuan/confidential-computing-zoo/cczoo/agent-cc/core/argus
+./start_argus.sh validate
+```
 
-# Then run the OpenViking example.
-cd ../../../adapters/OpenViking/examples
+Expected output:
+```
+[INFO] Validating environment...
+[INFO] Rust version: 1.96.0
+[INFO] TDX device found at /dev/tdx_guest
+[INFO] TSM configfs found
+[INFO] TSM report interface available
+```
 
-# Run the self-contained demo
+### Step 2: Build Argus Binaries
+
+```bash
+cargo build --release
+```
+
+### Step 3: Start Docker Compose Stack
+
+```bash
+cd /home/siyuan/confidential-computing-zoo/cczoo/agent-cc/adapters/OpenViking/examples
+docker-compose -f docker-compose.tc-api.yml up -d
+```
+
+Wait for services to be healthy:
+```bash
+curl http://127.0.0.1:8000/      # tc-api
+curl http://127.0.0.1:8008/health  # argus-provider
+```
+
+### Step 4: Run Full End-to-End Test
+
+For the complete real TDX quote attestation flow:
+
+```bash
+# Set your TC-API token
+export TC_API_IDENTITY_TOKEN="your-token-here"
+
+# Run the e2e test
+cd /home/siyuan/confidential-computing-zoo/cczoo/agent-cc/adapters/OpenViking/examples
+./run_openclaw_openviking_e2e.sh
+```
+
+This script:
+1. Starts the compose stack (registry + tc-api + argus-provider)
+2. Launches the OpenViking workload via tc-api
+3. Starts argus-guard in real-verifier mode
+4. Runs the OpenClaw example with full TDX attestation
+
+### Alternative: Run OpenViking Service Only (Demo Mode)
+
+For a quick in-memory demo without full attestation:
+
+```bash
+cd /home/siyuan/confidential-computing-zoo/cczoo/agent-cc/adapters/OpenViking/examples
 python3 openviking_service.py
+```
 
-# Or start the HTTP service mode
+Or start the HTTP gateway for manual testing:
+
+```bash
 python3 openviking_service.py --serve
 ```
 
-The default command runs a short in-memory demo and exits. `--serve` starts the
-HTTP gateway for manual testing.
-
-For the full real quote path, use `run_openclaw_openviking_e2e.sh` in this
-directory. It starts the compose stack, launches the tc-api-managed workload if
-needed, restarts Guard in real-verifier mode, and runs the OpenClaw example end
-to end.
+> **Note**: The demo mode (`openviking_service.py`) runs in-memory without real TDX quotes. For production or full attestation validation, use `run_openclaw_openviking_e2e.sh`.
 
 OpenViking itself does not start the Argus Evidence Provider. The intended flow
 is to start only the provider on the OpenViking side with

--- a/cczoo/agent-cc/core/argus/README_CN.md
+++ b/cczoo/agent-cc/core/argus/README_CN.md
@@ -16,6 +16,76 @@ Argus v1 已经用 Rust 实现，并在真实的 Intel TDX 硬件上完成了端
 - 已经与 [OpenClaw](../../adapters/OpenClaw) 和 [OpenViking](../../adapters/OpenViking) 适配器以及 `core/tc-api` 一起完成端到端验证，验证脚本见 `adapters/OpenViking/examples/run_openclaw_openviking_e2e.sh`。
 - TCB/collateral（基于 PCCS 的新鲜度校验）在 v1 中被有意排除在范围之外——原因见 [设计决策](./docs/design-decisions.md)。
 
+## 快速开始
+
+### 前置条件
+
+运行 Argus 需要：
+- Intel TDX 启用平台
+- Linux kernel 5.15+ 且支持 TDX
+- Rust 1.75+
+- `/dev/tdx_guest` 设备
+- TSM configfs 接口位于 `/sys/kernel/config/tsm/report/`
+
+### 步骤 1: 构建 Argus
+
+```bash
+cd /home/siyuan/confidential-computing-zoo/cczoo/agent-cc/core/argus
+cargo build --release
+```
+
+### 步骤 2: 验证环境
+
+```bash
+./start_argus.sh validate
+```
+
+预期输出：
+```
+[INFO] Validating environment...
+[INFO] Rust version: 1.96.0
+[INFO] TDX device found at /dev/tdx_guest
+[INFO] TSM configfs found
+[INFO] TSM report interface available
+```
+
+### 步骤 3: 启动服务
+
+```bash
+# 启动 Evidence Provider 和 Guard
+./start_argus.sh start
+
+# 检查服务状态
+./start_argus.sh status
+```
+
+### 步骤 4: 测试证明流程
+
+```bash
+# 运行证明测试
+./start_argus.sh test
+```
+
+预期输出：
+```
+[INFO] Testing attestation flow...
+[INFO] Attestation test: PASSED
+TEE type: tdx
+Quote valid: True
+```
+
+### 完整端到端测试
+
+要运行完整的 OpenClaw + OpenViking + Argus + TDX 验证流程：
+
+```bash
+cd /home/siyuan/confidential-computing-zoo/cczoo/agent-cc/adapters/OpenViking/examples
+export TC_API_IDENTITY_TOKEN=<your-token>
+./run_openclaw_openviking_e2e.sh
+```
+
+详细说明见 [OpenViking examples README](../../adapters/OpenViking/examples/README.md)。
+
 ## 文档
 
 - [快速开始](./docs/quickstart.md)：在本地或通过 Docker 构建、运行并冒烟测试 Argus。


### PR DESCRIPTION
- Add Prerequisites to all example READMEs
- Add Step 1-4 flow: validate environment, build, start services, run test
- Add architecture diagrams to OpenClaw and OpenViking READMEs
- Add Context Gateway Operations table to OpenViking README
- Add Integration Points with code examples to OpenClaw README
- Add expected output for validation commands
- Distinguish demo mode vs real TDX quote mode
- Sync Chinese README with Quick Start section
- Add Quick Start by Service section to top-level README

