### PR TITLE
Fix resource leaks in gRPC clients and TDX tools

### DIFF
--- a/cczoo/openclaw-cc/tdx_utility/src/tdxtools/tdeventlog.py
+++ b/cczoo/openclaw-cc/tdx_utility/src/tdxtools/tdeventlog.py
@@ -471,6 +471,7 @@ def check_initrd():
 
     td_event_log_actor.process()
 
-    initrd_digest = sha384(open('/boot/initrd.img','rb').read()).hexdigest()
+    with open('/boot/initrd.img', 'rb') as f:
+        initrd_digest = sha384(f.read()).hexdigest()
     events = td_event_log_actor.find_hash(initrd_digest)
     assert len(events) == 1

--- a/cczoo/tdx-tf-serving-ppml/client/resnet_client_grpc.py
+++ b/cczoo/tdx-tf-serving-ppml/client/resnet_client_grpc.py
@@ -91,7 +91,9 @@ class benchmark_engine(object):
                         tps = self.batch_size / latency
                         print(format_string.format('insecure', task_idx, self.batch_size, 1000*latency, tps))
         else:
-            creds = grpc.ssl_channel_credentials(root_certificates=open(self.certificate, 'rb').read())
+            with open(self.certificate, 'rb') as f:
+                cert_data = f.read()
+            creds = grpc.ssl_channel_credentials(root_certificates=cert_data)
             async with grpc.aio.secure_channel(self.url, creds) as channel:
                 stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
                 if loop_num != 0:

--- a/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/client/resnet_client_grpc.py
+++ b/cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/client/resnet_client_grpc.py
@@ -41,9 +41,21 @@ class benchmark_engine(object):
         self.batch_size = batch_size
         self.response_time = response_time
         self.concurrent_num = concurrent_num
-        self.root_cert = None if not root_cert else open(root_cert, 'rb').read()
-        self.private_key = None if not private_key else open(private_key, 'rb').read()
-        self.certificate_chain = None if not certificate_chain else open(certificate_chain, 'rb').read()
+        if root_cert:
+            with open(root_cert, 'rb') as f:
+                self.root_cert = f.read()
+        else:
+            self.root_cert = None
+        if private_key:
+            with open(private_key, 'rb') as f:
+                self.private_key = f.read()
+        else:
+            self.private_key = None
+        if certificate_chain:
+            with open(certificate_chain, 'rb') as f:
+                self.certificate_chain = f.read()
+        else:
+            self.certificate_chain = None
         self.request_signatures = []
         self.request_stubs = []
         self.__prepare__()


### PR DESCRIPTION
## Motivation

Several places in the codebase open files without using context managers (`with` statements), which can leak file descriptors if an exception occurs between `open()` and the implicit close. This is particularly important in security-sensitive code like TDX attestation and gRPC client authentication.

## Changes

- **`cczoo/tdx-tf-serving-ppml/client/resnet_client_grpc.py`**: Replaced `open(self.certificate, 'rb').read()` with a `with` statement to ensure the certificate file is properly closed after reading.

- **`cczoo/tensorflow-serving-cluster/tensorflow-serving/docker/client/resnet_client_grpc.py`**: Replaced three inline `open(..., 'rb').read()` calls (for `root_cert`, `private_key`, `certificate_chain`) with `with` statements to ensure all credential files are properly closed.

- **`cczoo/openclaw-cc/tdx_utility/src/tdxtools/tdeventlog.py`**: Replaced `sha384(open('/boot/initrd.img','rb').read())` with a `with` statement to ensure the initrd image file is properly closed after computing its hash.

## Testing

These are defensive resource management improvements that do not change functional behavior. The existing logic remains identical.
